### PR TITLE
README.md: Fixed Python Kafka library name and added libssl development

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,15 +262,16 @@ The RVI Backend requires additional Python modules to function:
 
 9. Cryptography Library
 
-   The Cryptography library requires the libffi development library, 
-   libffi-devel on Fedora and OpenSUSE, libffi-dev on Debian and Ubuntu, to
-   be installed. Install it first, then install
+   The Cryptography library requires the libffi development library as well as
+   the libssl development library. The names of the packages to be installed
+   are libffi-devel and libssl-devel on Fedora and OpenSUSE; libffi-dev and 
+   libssl-devel on Debian and Ubuntu. Install them first, then install
 
         sudo pip install cryptography
 
 10. Kafka Library
 
-        sudo pip install python-kafka
+        sudo pip install kafka-python
         
 11. HBase Library
 


### PR DESCRIPTION
The name of the Python Kafka library was mispelled. It should have been
kafka-python rather than python-kafka. And besides libffi-dev/-devel
libssh-dev/-devel is required.

Signed-off-by: Rudolf J Streif <rudolf.streif@gmail.com>